### PR TITLE
Use installs items method for Nessus

### DIFF
--- a/Nessus/Nessus.download.recipe
+++ b/Nessus/Nessus.download.recipe
@@ -34,7 +34,7 @@
               <key>Arguments</key>
               <dict>
                   <key>url</key>
-                  <string>https://www.tenable.com/downloads/nessus-agents</string>
+                  <string>%url%</string>
                   <key>result_output_var_name</key>
                   <string>version</string>
                   <key>re_pattern</key>
@@ -49,7 +49,7 @@
                     <key>url</key>
                     <string>https://www.tenable.com/downloads/api/v1/public/pages/nessus-agents/downloads/%download_id%/download?i_agree_to_tenable_license_agreement=true</string>
                     <key>CHECK_FILESIZE_ONLY</key>
-                    <true />
+                    <true/>
                     <key>filename</key>
                     <string>%NAME%-%version%.dmg</string>
                 </dict>

--- a/Nessus/Nessus.munki.recipe
+++ b/Nessus/Nessus.munki.recipe
@@ -38,6 +38,48 @@
     <array>
         <dict>
             <key>Processor</key>
+            <string>FlatPkgUnpacker</string>
+            <key>Arguments</key>
+            <dict>
+                <key>flat_pkg_path</key>
+                <string>%pathname%/.NessusAgent.pkg</string>
+                <key>destination_path</key>
+                <string>%RECIPE_CACHE_DIR%/unpack</string>
+            </dict>
+        </dict>
+        <dict>
+            <key>Processor</key>
+            <string>PkgPayloadUnpacker</string>
+            <key>Arguments</key>
+            <dict>
+                <key>pkg_payload_path</key>
+                <string>%RECIPE_CACHE_DIR%/unpack/Payload</string>
+                <key>destination_path</key>
+                <string>%RECIPE_CACHE_DIR%/payload</string>
+            </dict>
+        </dict>
+        <dict>
+            <key>Processor</key>
+            <string>MunkiInstallsItemsCreator</string>
+            <key>Arguments</key>
+            <dict>
+                <key>faux_root</key>
+                <string>%RECIPE_CACHE_DIR%/payload</string>
+                <key>installs_item_paths</key>
+                <array>
+                    <string>/Library/NessusAgent/run/sbin/nessus-service</string>
+                    <string>/Library/NessusAgent/run/sbin/nessuscli</string>
+                    <string>/Library/NessusAgent/run/sbin/nessusd</string>
+                    <string>/Library/NessusAgent/run/sbin/nessusmgt</string>
+                </array>
+            </dict>
+        </dict>
+        <dict>
+            <key>Processor</key>
+            <string>MunkiPkginfoMerger</string>
+        </dict>
+        <dict>
+            <key>Processor</key>
             <string>MunkiPkginfoMerger</string>
             <key>Arguments</key>
             <dict>
@@ -45,36 +87,6 @@
                 <dict>
                     <key>version</key>
                     <string>%version%</string>
-                    <key>installcheck_script</key>
-                    <string>#!/bin/zsh
-
-# binaries
-cli="/Library/NessusAgent/run/sbin/nessuscli"
-service="/Library/NessusAgent/run/sbin/nessus-service"
-
-# versions
-current_version=$($cli --version | awk 'NR==1{print $4}')
-target_version="%version%"
-
-# install status outcomes
-missing="Did not detect a Tenable Nessus install (target version: ${target_version}). Install/update needed."
-outdated="Detected an outdated Tenable Nessus (current version ${current_version}, target version: ${target_version}). Install/update needed."
-updated="Detected an up-to-date Tenable Nessus (current version: ${current_version}, target version: ${target_version}). No install/update needed."
-installed=1
-not_installed=0
-
-if [[ ! -f "$cli" ]] || [[ ! -f "$service" ]]; then
-    echo "$missing"
-    exit "$not_installed"
-elif [[ "$current_version" != "$target_version" ]]; then
-    echo "$outdated"
-    exit "$not_installed"
-elif [[ "$current_version" == "$target_version" ]]; then
-    echo "$updated"
-    exit "$installed"
-else
-    exit 0
-fi</string>
                 </dict>
             </dict>
         </dict>

--- a/Nessus/Nessus.munki.recipe
+++ b/Nessus/Nessus.munki.recipe
@@ -54,7 +54,7 @@ service="/Library/NessusAgent/run/sbin/nessus-service"
 
 # versions
 current_version=$($cli --version | awk 'NR==1{print $4}')
-target_version=%version%
+target_version="%version%"
 
 # install status outcomes
 missing="Did not detect a Tenable Nessus install (target version: ${target_version}). Install/update needed."

--- a/Nessus/Nessus.munki.recipe
+++ b/Nessus/Nessus.munki.recipe
@@ -2,77 +2,93 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-	<key>Description</key>
-	<string>Downloads the latest version of Nessus and imports into Munki.</string>
-	<key>Identifier</key>
-	<string>com.github.williamtheaker.autopkg.munki.Nessus</string>
-	<key>Input</key>
-	<dict>
-		<key>MUNKI_REPO_SUBDIR</key>
-		<string>apps</string>
-		<key>NAME</key>
-		<string>Nessus</string>
-		<key>pkginfo</key>
-		<dict>
-			<key>catalogs</key>
-			<array>
-				<string>testing</string>
-			</array>
-			<key>description</key>
-			<string>Nessus is a vulnerability assessment tool.</string>
-			<key>developer</key>
-			<string>Tenable</string>
-			<key>display_name</key>
-			<string>Nessus Agent</string>
-			<key>name</key>
-			<string>%NAME%</string>
-			<key>unattended_install</key>
-			<true/>
-		</dict>
-	</dict>
-	<key>MinimumVersion</key>
-	<string>0.2.0</string>
-	<key>ParentRecipe</key>
-	<string>com.github.williamtheaker.autopkg.download.Nessus</string>
-	<key>Process</key>
-	<array>
-		<dict>
-			<key>Processor</key>
-			<string>MunkiPkginfoMerger</string>
-	      <key>Arguments</key>
-	      <dict>
-	          <key>additional_pkginfo</key>
-	          <dict>
-	              <key>version</key>
-	              <string>%version%</string>
-								<key>installcheck_script</key>
-								<string>#!/bin/bash
+    <key>Description</key>
+    <string>Downloads the latest version of Nessus and imports into Munki.</string>
+    <key>Identifier</key>
+    <string>com.github.williamtheaker.autopkg.munki.Nessus</string>
+    <key>Input</key>
+    <dict>
+        <key>MUNKI_REPO_SUBDIR</key>
+        <string>apps</string>
+        <key>NAME</key>
+        <string>Nessus</string>
+        <key>pkginfo</key>
+        <dict>
+            <key>catalogs</key>
+            <array>
+                <string>testing</string>
+            </array>
+            <key>description</key>
+            <string>Nessus is a vulnerability assessment tool.</string>
+            <key>developer</key>
+            <string>Tenable</string>
+            <key>display_name</key>
+            <string>Nessus Agent</string>
+            <key>name</key>
+            <string>%NAME%</string>
+            <key>unattended_install</key>
+            <true/>
+        </dict>
+    </dict>
+    <key>MinimumVersion</key>
+    <string>0.5.0</string>
+    <key>ParentRecipe</key>
+    <string>com.github.williamtheaker.autopkg.download.Nessus</string>
+    <key>Process</key>
+    <array>
+        <dict>
+            <key>Processor</key>
+            <string>MunkiPkginfoMerger</string>
+            <key>Arguments</key>
+            <dict>
+                <key>additional_pkginfo</key>
+                <dict>
+                    <key>version</key>
+                    <string>%version%</string>
+                    <key>installcheck_script</key>
+                    <string>#!/bin/zsh
 
+# binaries
+cli="/Library/NessusAgent/run/sbin/nessuscli"
+service="/Library/NessusAgent/run/sbin/nessus-service"
+
+# versions
+current_version=$($cli --version | awk 'NR==1{print $4}')
 target_version=%version%
 
-if [ -f "/Library/NessusAgent/run/sbin/nessus-service" ]; then
-  current_version=$(/Library/NessusAgent/run/sbin/nessus-service -v | grep 'build' | awk '{print $3}')
-  if [ "$current_version" == "$target_version" ]; then
-    exit 1
-  fi
-fi
+# install status outcomes
+missing="Did not detect a Tenable Nessus install (target version: ${target_version}). Install/update needed."
+outdated="Detected an outdated Tenable Nessus (current version ${current_version}, target version: ${target_version}). Install/update needed."
+updated="Detected an up-to-date Tenable Nessus (current version: ${current_version}, target version: ${target_version}). No install/update needed."
+installed=1
+not_installed=0
 
-exit 0
-</string>
-	          </dict>
-	      </dict>
-      </dict>
-		<dict>
-			<key>Processor</key>
-			<string>MunkiImporter</string>
-			<key>Arguments</key>
-			<dict>
-				<key>pkg_path</key>
-				<string>%pathname%</string>
-				<key>repo_subdirectory</key>
-				<string>%MUNKI_REPO_SUBDIR%</string>
-			</dict>
-		</dict>
-	</array>
+if [[ ! -f "$cli" ]] || [[ ! -f "$service" ]]; then
+    echo "$missing"
+    exit "$not_installed"
+elif [[ "$current_version" != "$target_version" ]]; then
+    echo "$outdated"
+    exit "$not_installed"
+elif [[ "$current_version" == "$target_version" ]]; then
+    echo "$updated"
+    exit "$installed"
+else
+    exit 0
+fi</string>
+                </dict>
+            </dict>
+        </dict>
+        <dict>
+            <key>Processor</key>
+            <string>MunkiImporter</string>
+            <key>Arguments</key>
+            <dict>
+                <key>pkg_path</key>
+                <string>%pathname%</string>
+                <key>repo_subdirectory</key>
+                <string>%MUNKI_REPO_SUBDIR%</string>
+            </dict>
+        </dict>
+    </array>
 </dict>
 </plist>


### PR DESCRIPTION
Does away with a `installcheck_script` which could break in the future in favor of file based installs items. Binary paths could change as well, but at least in that scenario the recipe would fail before being imported. Uses all binaries in `/Library/NessusAgent/run/sbin`.