### PR TITLE
Add Zscaler install recipes

### DIFF
--- a/Zscaler/README.md
+++ b/Zscaler/README.md
@@ -1,0 +1,7 @@
+# Zscaler recipes
+
+Original recipes forked from [rtrouton-recipes](https://github.com/autopkg/rtrouton-recipes/tree/master/Zscaler).
+
+Change the `DESIRED_VERSION` input variable to match the version to download. As long as Zscaler doesn't change the Cloudfront CDN URL this should continue to work. Please open a PR or file an issue if/when it doesn't.
+
+There are two Munki recipes - one which installs the generated package and one which doesn't. The only advantage of installing the Zscaler package is a resulting installs array in the Munki pkginfo. If receipt based install logic is enough in your scenario, use `Zscaler.munki.recipe`, otherwise consider `Zscaler-Install.munki.recipe`. In situations where Autopkg is run ephemerally within CI, this install only adds a trivial amount of time. There may be other considerations when running Autopkg on a static box.

--- a/Zscaler/Zscaler-Install.munki.recipe
+++ b/Zscaler/Zscaler-Install.munki.recipe
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
     <key>Description</key>
-    <string>Downloads the requested version of Zscaler and imports into Munki.</string>
+    <string>Downloads the requested version of Zscaler, installs it, and imports into Munki.</string>
     <key>Identifier</key>
     <string>com.github.williamtheaker.autopkg.munki.Zscaler</string>
     <key>Input</key>
@@ -38,9 +38,24 @@
     <key>MiniumumVersion</key>
     <string>2.4.1</string>
     <key>ParentRecipe</key>
-    <string>com.github.williamtheaker.autopkg.pkg.Zscaler</string>
+    <string>com.github.williamtheaker.autopkg.install.Zscaler</string>
     <key>Process</key>
     <array>
+        <dict>
+            <key>Processor</key>
+            <string>MunkiInstallsItemsCreator</string>
+            <key>Arguments</key>
+            <dict>
+                <key>installs_item_paths</key>
+                <array>
+                    <string>/Applications/Zscaler/Zscaler.app</string>
+                </array>
+            </dict>
+        </dict>
+        <dict>
+            <key>Processor</key>
+            <string>MunkiPkginfoMerger</string>
+        </dict>
         <dict>
             <key>Processor</key>
             <string>MunkiImporter</string>

--- a/Zscaler/Zscaler.download.recipe
+++ b/Zscaler/Zscaler.download.recipe
@@ -11,7 +11,7 @@
         <key>NAME</key>
         <string>Zscaler</string>
         <key>DESIRED_VERSION</key>
-        <string>3.6.1.19</string>
+        <string>3.7.0.176</string>
     </dict>
     <key>MiniumumVersion</key>
     <string>2.4.1</string>
@@ -19,19 +19,19 @@
     <array>
         <dict>
             <key>Processor</key>
-            <string>URLDownloaderPython</string>
+            <string>URLDownloader</string>
             <key>Arguments</key>
         <dict>
             <key>url</key>
             <string>https://d32a6ru7mhaq0c.cloudfront.net/Zscaler-osx-%DESIRED_VERSION%-installer.app.zip</string>
         </dict>
-    </dict>
-    <dict>
-        <key>Processor</key>
-        <string>EndOfCheckPhase</string>
-        <key>Comment</key>
-        <string>End new version phase.</string>
-    </dict>
+        </dict>
+        <dict>
+            <key>Processor</key>
+            <string>EndOfCheckPhase</string>
+            <key>Comment</key>
+            <string>End new version phase.</string>
+        </dict>
         <dict>
             <key>Processor</key>
             <string>Unarchiver</string>

--- a/Zscaler/Zscaler.install.recipe
+++ b/Zscaler/Zscaler.install.recipe
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Description</key>
+    <string>Downloads the requested version of Zscaler for macOS, packages, and installs it.</string>
+    <key>Identifier</key>
+    <string>com.github.williamtheaker.autopkg.install.Zscaler</string>
+    <key>Input</key>
+    <dict>
+        <key>NAME</key>
+        <string>Zscaler</string>
+    </dict>
+    <key>MinimumVersion</key>
+    <string>1.0.0</string>
+    <key>ParentRecipe</key>
+    <string>com.github.williamtheaker.autopkg.pkg.Zscaler</string>
+    <key>Process</key>
+    <array>
+        <dict>
+            <key>Processor</key>
+            <string>Installer</string>
+            <key>Arguments</key>
+            <dict>
+               <key>pkg_path</key>
+               <string>%pkg_path%</string>
+            </dict>
+        </dict>
+    </array>
+</dict>
+</plist>

--- a/Zscaler/Zscaler.install.recipe
+++ b/Zscaler/Zscaler.install.recipe
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
     <key>Description</key>
-    <string>Downloads the requested version of Zscaler for macOS, packages, and installs it.</string>
+    <string>Downloads the requested version of Zscaler, packages, and installs it.</string>
     <key>Identifier</key>
     <string>com.github.williamtheaker.autopkg.install.Zscaler</string>
     <key>Input</key>

--- a/Zscaler/Zscaler.munki.recipe
+++ b/Zscaler/Zscaler.munki.recipe
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
     <key>Description</key>
-    <string>Downloads the requested version of Zscaler and imports into Munki.</string>
+    <string>Downloads the requested version of Zscaler, packages, and imports it into Munki.</string>
     <key>Identifier</key>
     <string>com.github.williamtheaker.autopkg.munki.Zscaler</string>
     <key>Input</key>

--- a/Zscaler/Zscaler.pkg.recipe
+++ b/Zscaler/Zscaler.pkg.recipe
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
     <key>Description</key>
-    <string>Downloads the requested version of Zscaler for macOS and packages it for installation. Forked from com.github.rtrouton.pkg.zscaler.</string>
+    <string>Downloads the requested version of Zscaler and packages it.</string>
     <key>Identifier</key>
     <string>com.github.williamtheaker.autopkg.pkg.Zscaler</string>
     <key>Input</key>


### PR DESCRIPTION
Turns out the installs array stuff I added previously doesn't work unless Zscaler is already installed. Great for running locally, not so much in CI. This is my workaround for having to manually build an installs array on every new version import. Since runs are ephemeral anyway, adding an install step isn't much more overhead.

- Update README.
- Add Zscaler.install and Zscaler-Install.munki recipes.
- Revert installs array processors in regular Zscaler.munki recipe.