### PR TITLE
Update Cinc version parsing library

### DIFF
--- a/Cinc/Cinc.munki.recipe
+++ b/Cinc/Cinc.munki.recipe
@@ -53,7 +53,8 @@ import plistlib
 import subprocess
 import sys
 import time
-from distutils.version import LooseVersion as version
+
+from pkg_resources import parse_version as version
 
 CINC_VERSION = "%version%"
 CINC_PATH = "/opt/cinc/bin/cinc-client"


### PR DESCRIPTION
```
/tmp/munki-0kxf_c48/installcheck_script:42: DeprecationWarning: distutils Version classes are deprecated. Use packaging.version instead.
  if version(installed_version) < version(CINC_VERSION):
```
Munki as a whole will have to deal with this, but better to get ahead of it. `disutils` is deprecated and will be removed entirely in a future Python version. Use `pkg_resources` (https://setuptools.pypa.io/en/latest/pkg_resources.html#parsing-utilities) instead which is part of standard lib thanks to `setuptools`. Since Cinc uses reasonable versioning logic remains the same otherwise. 
