### PR TITLE
Update Teleport.download.recipe

### DIFF
--- a/Teleport/Teleport.download.recipe
+++ b/Teleport/Teleport.download.recipe
@@ -43,6 +43,21 @@
             <key>Processor</key>
             <string>EndOfCheckPhase</string>
         </dict>
+        <dict>
+        <key>Arguments</key>
+        <dict>
+            <key>input_path</key>
+            <string>%pathname%</string>
+            <key>expected_authority_names</key>
+            <array>
+                <string>Developer ID Installer: Gravitational Inc. (QH8AA5B8UP)</string>
+                <string>Developer ID Certification Authority</string>
+                <string>Apple Root CA</string>
+            </array>
+        </dict>
+        <key>Processor</key>
+        <string>CodeSignatureVerifier</string>
+        </dict>
     </array>
 </dict>
 </plist>

--- a/Teleport/Teleport.download.recipe
+++ b/Teleport/Teleport.download.recipe
@@ -19,9 +19,9 @@
         <key>Arguments</key>
         <dict>
             <key>url</key>
-            <string>https://goteleport.com/download/</string>
+            <string>https://goteleport.com/docs/installation/#macos</string>
             <key>re_pattern</key>
-            <string>https:\/\/cdn.teleport.dev\/teleport-([\d\.]*).pkg</string>
+            <string>teleport-([0-9]+(\.[0-9]+)+).pkg</string>
             <key>result_output_var_name</key>
             <string>version</string>
         </dict>


### PR DESCRIPTION
Hi, @williamtheaker 

The Teleport Recipes are currently failing with 
```
 Error in local.definition.Teleport: Processor: URLTextSearcher: Error: No match found on URL: https://goteleport.com/download/
```

This PR updates the search URL and regex

Output from a successful -v run
```
autopkg run -v Teleport.munki.recipe
Looking for com.github.williamtheaker.autopkg.download.Teleport...
Did not find com.github.williamtheaker.autopkg.download.Teleport in recipe map
Rebuilding recipe map with current working directories...
Looking for com.github.williamtheaker.autopkg.download.Teleport...
Found com.github.williamtheaker.autopkg.download.Teleport in recipe map
**load_recipe time: 0.011221207999369653
Processing Teleport.munki.recipe...
WARNING: Teleport.munki.recipe is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
URLTextSearcher
URLTextSearcher: Found matching text (version): 17.2.9
URLDownloader
URLDownloader: Storing new Last-Modified header: Tue, 25 Feb 2025 20:42:20 GMT
URLDownloader: Storing new ETag header: "69528caab02993b053c38fcb2076386c"
URLDownloader: Downloaded /Users/paul.cossey/Library/AutoPkg/Cache/com.github.williamtheaker.autopkg.munki.Teleport/downloads/Teleport-17.2.9.pkg
EndOfCheckPhase
CodeSignatureVerifier
CodeSignatureVerifier: Verifying installer package signature...
CodeSignatureVerifier: Package "Teleport-17.2.9.pkg":
CodeSignatureVerifier:    Status: signed by a developer certificate issued by Apple for distribution
CodeSignatureVerifier:    Notarization: trusted by the Apple notary service
CodeSignatureVerifier:    Signed with a trusted timestamp on: 2025-02-25 19:56:20 +0000
CodeSignatureVerifier:    Certificate Chain:
CodeSignatureVerifier:     1. Developer ID Installer: Gravitational Inc. (QH8AA5B8UP)
CodeSignatureVerifier:        Expires: 2028-04-06 21:18:44 +0000
CodeSignatureVerifier:        SHA256 Fingerprint:
CodeSignatureVerifier:            5D 8B F7 91 14 81 F3 AE AA 13 91 EE 6A 29 30 3B C8 49 10 23 F8 68 
CodeSignatureVerifier:            04 E6 35 FF EB F9 FE 09 08 A2
CodeSignatureVerifier:        ------------------------------------------------------------------------
CodeSignatureVerifier:     2. Developer ID Certification Authority
CodeSignatureVerifier:        Expires: 2031-09-17 00:00:00 +0000
CodeSignatureVerifier:        SHA256 Fingerprint:
CodeSignatureVerifier:            F1 6C D3 C5 4C 7F 83 CE A4 BF 1A 3E 6A 08 19 C8 AA A8 E4 A1 52 8F 
CodeSignatureVerifier:            D1 44 71 5F 35 06 43 D2 DF 3A
CodeSignatureVerifier:        ------------------------------------------------------------------------
CodeSignatureVerifier:     3. Apple Root CA
CodeSignatureVerifier:        Expires: 2035-02-09 21:40:36 +0000
CodeSignatureVerifier:        SHA256 Fingerprint:
CodeSignatureVerifier:            B0 B1 73 0E CB C7 FF 45 05 14 2C 49 F1 29 5E 6E DA 6B CA ED 7E 2C 
CodeSignatureVerifier:            68 C5 BE 91 B5 A1 10 01 F0 24
CodeSignatureVerifier: 
CodeSignatureVerifier: Signature is valid
CodeSignatureVerifier: Authority name chain is valid
MunkiImporter
MunkiImporter: Using repo lib: AutoPkgLib
MunkiImporter:         plugin: FileRepo
MunkiImporter:           repo: /Users/Shared/munki_repo
MunkiImporter: Copied pkginfo to: /Users/Shared/munki_repo/pkgsinfo/apps/Teleport-17.2.9.plist
MunkiImporter:            pkg to: /Users/Shared/munki_repo/pkgs/apps/Teleport-17.2.9.pkg
Receipt written to /Users/paul.cossey/Library/AutoPkg/Cache/com.github.williamtheaker.autopkg.munki.Teleport/receipts/Teleport.munki-receipt-20250227-165745.plist

The following new items were downloaded:
    Download Path                                                                                                            
    -------------                                                                                                            
    /Users/paul.cossey/Library/AutoPkg/Cache/com.github.williamtheaker.autopkg.munki.Teleport/downloads/Teleport-17.2.9.pkg  

The following new items were imported into Munki:
    Name      Version  Catalogs  Pkginfo Path                Pkg Repo Path             Icon Repo Path  
    ----      -------  --------  ------------                -------------             --------------  
    Teleport  17.2.9   testing   apps/Teleport-17.2.9.plist  apps/Teleport-17.2.9.pkg
```